### PR TITLE
Removing -I flag when splitting a window

### DIFF
--- a/lua/tmux-awesome-manager/src/adapters/tmux.lua
+++ b/lua/tmux-awesome-manager/src/adapters/tmux.lua
@@ -20,7 +20,7 @@ function M.open_pane(cmd, size, orientation, cwd, focus)
 	local dir = orientation == "horizontal" and " -h " or " -v "
 	local extra = focus and "" or " -d "
 	if cwd then extra = extra .. " -c " .. cwd .. " " end
-	local result = vim.fn.system(b() .. " split-window -P -I -l " .. (size or "50%") .. dir .. extra .. ' -F "#{pane_id}" "' .. cmd .. '"')
+	local result = vim.fn.system(b() .. " split-window -P -l " .. (size or "50%") .. dir .. extra .. ' -F "#{pane_id}" "' .. cmd .. '"')
 	return normalize(result)
 end
 


### PR DESCRIPTION
The -I flag tells tmux to create an empty pane that just pipes stdin into it; it's mutually exclusive with also passing a command. On tmux versions up to 3.6 the -I fails silently, now on 3.7+ it hard errors.

This change is retrocompatible with older tmux versions than 3.7 since we almost never want to create an empty pane and send a command attached. Even when only a console is needed, the bash command is passed (or other shell)